### PR TITLE
feat: add bulk rename functionality with multiple naming formats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,21 @@ function App() {
     );
   }, []);
 
+  const handleBulkRename = useCallback((renamedFiles: Map<string, string>) => {
+    setProcessedImages((prev) =>
+      prev.map((img) => {
+        const newFileName = renamedFiles.get(img.id);
+        return newFileName ? { ...img, customFileName: newFileName } : img;
+      })
+    );
+
+    notifications.show({
+      title: 'Files Renamed',
+      message: `Successfully renamed ${renamedFiles.size} ${renamedFiles.size === 1 ? 'file' : 'files'}`,
+      color: 'green',
+    });
+  }, []);
+
   const regenerateAllImages = useCallback(() => {
     // Reset all images to unprocessed state to trigger reprocessing
     setProcessedImages((prev) =>
@@ -325,6 +340,7 @@ function App() {
                   onClearAll={handleClearAll}
                   onReorderImages={handleReorderImages}
                   onUpdateFileName={handleUpdateFileName}
+                  onBulkRename={handleBulkRename}
                   viewMode={viewMode}
                 />
 

--- a/src/components/features/BulkRenameModal.tsx
+++ b/src/components/features/BulkRenameModal.tsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Modal,
+  Stack,
+  Group,
+  Text,
+  Button,
+  Paper,
+  Badge,
+  SegmentedControl,
+  TextInput,
+  NumberInput,
+  Code,
+} from '@mantine/core';
+import { Edit2, Check, FileText } from 'lucide-react';
+import { NAMING_FORMATS, generatePreview, bulkRename } from '../../utils/namingFormats';
+import { ProcessedImage } from '../../types';
+
+interface BulkRenameModalProps {
+  opened: boolean;
+  onClose: () => void;
+  images: ProcessedImage[];
+  onApply: (renamedFiles: Map<string, string>) => void;
+}
+
+export function BulkRenameModal({ opened, onClose, images, onApply }: BulkRenameModalProps) {
+  const [selectedFormat, setSelectedFormat] = useState<string>('sequential');
+  const [customPrefix, setCustomPrefix] = useState<string>('');
+  const [startNumber, setStartNumber] = useState<number>(1);
+  const [preview, setPreview] = useState<string[]>([]);
+
+  // Get current format
+  const currentFormat = NAMING_FORMATS.find((f) => f.id === selectedFormat);
+
+  // Update preview whenever settings change
+  useEffect(() => {
+    if (!opened) return;
+
+    const imageData = images.map((img) => ({
+      originalName: img.originalFile.name,
+      outputFormat: img.outputFormat || 'jpeg',
+    }));
+
+    const previewNames = generatePreview(selectedFormat, imageData, {
+      prefix: customPrefix,
+      startNumber,
+      previewCount: 3,
+    });
+
+    setPreview(previewNames);
+  }, [opened, selectedFormat, customPrefix, startNumber, images]);
+
+  const handleApply = () => {
+    const imageData = images.map((img) => ({
+      id: img.id,
+      originalName: img.originalFile.name,
+      outputFormat: img.outputFormat || 'jpeg',
+    }));
+
+    const renamedFiles = bulkRename(selectedFormat, imageData, {
+      prefix: customPrefix,
+      startNumber,
+    });
+
+    onApply(renamedFiles);
+    onClose();
+  };
+
+  const handleCancel = () => {
+    // Reset to defaults
+    setSelectedFormat('sequential');
+    setCustomPrefix('');
+    setStartNumber(1);
+    onClose();
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleCancel}
+      title={
+        <Group gap="xs">
+          <Edit2 size={20} />
+          <Text size="lg" fw={600}>
+            Bulk Rename Files
+          </Text>
+        </Group>
+      }
+      size="lg"
+      centered
+    >
+      <Stack gap="lg">
+        {/* Info Banner */}
+        <Paper p="md" radius="md" withBorder style={{ backgroundColor: 'var(--color-bg-secondary)' }}>
+          <Group gap="xs">
+            <FileText size={18} color="var(--mantine-color-blue-6)" />
+            <Text size="sm" c="dimmed">
+              Rename all <strong>{images.length}</strong> processed {images.length === 1 ? 'image' : 'images'} at once
+            </Text>
+          </Group>
+        </Paper>
+
+        {/* Format Selector */}
+        <Stack gap="xs">
+          <Text size="sm" fw={600}>
+            Naming Format
+          </Text>
+          <SegmentedControl
+            value={selectedFormat}
+            onChange={setSelectedFormat}
+            data={NAMING_FORMATS.map((format) => ({
+              value: format.id,
+              label: format.name,
+            }))}
+            fullWidth
+          />
+          {currentFormat && (
+            <Text size="xs" c="dimmed" style={{ marginTop: -4 }}>
+              {currentFormat.description}
+            </Text>
+          )}
+        </Stack>
+
+        {/* Custom Prefix Input (conditional) */}
+        {currentFormat?.requiresPrefix && (
+          <TextInput
+            label="Custom Prefix"
+            placeholder="Enter prefix (e.g., vacation, portfolio)"
+            value={customPrefix}
+            onChange={(e) => setCustomPrefix(e.target.value)}
+            description="Letters, numbers, hyphens, and underscores allowed"
+            leftSection={<Edit2 size={16} />}
+          />
+        )}
+
+        {/* Start Number Input */}
+        <NumberInput
+          label="Start Number"
+          placeholder="1"
+          value={startNumber}
+          onChange={(value) => setStartNumber(typeof value === 'number' ? value : 1)}
+          min={0}
+          max={9999}
+          description="First file will start with this number"
+        />
+
+        {/* Preview Section */}
+        <Paper p="md" radius="md" withBorder style={{ backgroundColor: 'var(--color-bg-elevated)' }}>
+          <Stack gap="sm">
+            <Group justify="space-between">
+              <Text size="sm" fw={600}>
+                Preview
+              </Text>
+              <Badge size="sm" variant="light" color="blue">
+                First {Math.min(3, images.length)} {images.length === 1 ? 'file' : 'files'}
+              </Badge>
+            </Group>
+
+            {preview.length > 0 ? (
+              <Stack gap="xs">
+                {preview.map((filename, index) => (
+                  <Group key={index} gap="xs">
+                    <Text size="xs" c="dimmed" style={{ minWidth: 20 }}>
+                      {startNumber + index}.
+                    </Text>
+                    <Code style={{ flex: 1, fontSize: '12px' }}>{filename}</Code>
+                  </Group>
+                ))}
+                {images.length > 3 && (
+                  <Text size="xs" c="dimmed" style={{ fontStyle: 'italic' }}>
+                    ... and {images.length - 3} more {images.length - 3 === 1 ? 'file' : 'files'}
+                  </Text>
+                )}
+              </Stack>
+            ) : (
+              <Text size="sm" c="dimmed">
+                No preview available
+              </Text>
+            )}
+          </Stack>
+        </Paper>
+
+        {/* Action Buttons */}
+        <Group justify="space-between" mt="md">
+          <Button variant="subtle" color="gray" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            leftSection={<Check size={18} />}
+            color="red"
+            onClick={handleApply}
+            disabled={currentFormat?.requiresPrefix && !customPrefix.trim()}
+          >
+            Apply to All {images.length} {images.length === 1 ? 'Image' : 'Images'}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/features/BulkRenameModal.tsx
+++ b/src/components/features/BulkRenameModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Modal,
   Stack,
@@ -32,14 +32,18 @@ export function BulkRenameModal({ opened, onClose, images, onApply }: BulkRename
   // Get current format
   const currentFormat = NAMING_FORMATS.find((f) => f.id === selectedFormat);
 
+  // Memoize image data transformation to avoid recalculating on every render
+  const imageData = useMemo(() =>
+    images.map((img) => ({
+      originalName: img.originalFile.name,
+      outputFormat: img.outputFormat || 'jpeg',
+    })),
+    [images]
+  );
+
   // Update preview whenever settings change
   useEffect(() => {
     if (!opened) return;
-
-    const imageData = images.map((img) => ({
-      originalName: img.originalFile.name,
-      outputFormat: img.outputFormat || 'jpeg',
-    }));
 
     const previewNames = generatePreview(selectedFormat, imageData, {
       prefix: customPrefix,
@@ -48,16 +52,16 @@ export function BulkRenameModal({ opened, onClose, images, onApply }: BulkRename
     });
 
     setPreview(previewNames);
-  }, [opened, selectedFormat, customPrefix, startNumber, images]);
+  }, [opened, selectedFormat, customPrefix, startNumber, imageData]);
 
   const handleApply = () => {
-    const imageData = images.map((img) => ({
+    const imageDataWithIds = images.map((img) => ({
       id: img.id,
       originalName: img.originalFile.name,
       outputFormat: img.outputFormat || 'jpeg',
     }));
 
-    const renamedFiles = bulkRename(selectedFormat, imageData, {
+    const renamedFiles = bulkRename(selectedFormat, imageDataWithIds, {
       prefix: customPrefix,
       startNumber,
     });

--- a/src/components/features/DownloadAll.tsx
+++ b/src/components/features/DownloadAll.tsx
@@ -17,11 +17,10 @@ import { BulkRenameModal } from "./BulkRenameModal";
 
 interface DownloadAllProps {
   images: ProcessedImage[];
-  onClearAll?: () => void;
   onBulkRename?: (renamedFiles: Map<string, string>) => void;
 }
 
-export function DownloadAll({ images, onClearAll, onBulkRename }: DownloadAllProps) {
+export function DownloadAll({ images, onBulkRename }: DownloadAllProps) {
   const [showRenameModal, setShowRenameModal] = useState(false);
   const handleDownloadAll = async () => {
     const zip = new JSZip();

--- a/src/components/features/DownloadAll.tsx
+++ b/src/components/features/DownloadAll.tsx
@@ -1,5 +1,6 @@
 // React import not required with new JSX transform
-import { Download, Package, TrendingDown, Check, Trash2, Sparkles, Archive, CheckCircle2 } from "lucide-react";
+import { useState } from "react";
+import { Download, Package, TrendingDown, Check, Trash2, Sparkles, Archive, CheckCircle2, Edit2 } from "lucide-react";
 import {
   Paper,
   Group,
@@ -12,13 +13,16 @@ import {
 import JSZip from "jszip";
 import { ProcessedImage } from "../../types";
 import { formatFileSize } from "../../utils/fileUtils";
+import { BulkRenameModal } from "./BulkRenameModal";
 
 interface DownloadAllProps {
   images: ProcessedImage[];
   onClearAll?: () => void;
+  onBulkRename?: (renamedFiles: Map<string, string>) => void;
 }
 
-export function DownloadAll({ images, onClearAll }: DownloadAllProps) {
+export function DownloadAll({ images, onClearAll, onBulkRename }: DownloadAllProps) {
+  const [showRenameModal, setShowRenameModal] = useState(false);
   const handleDownloadAll = async () => {
     const zip = new JSZip();
 
@@ -95,20 +99,20 @@ export function DownloadAll({ images, onClearAll }: DownloadAllProps) {
         <Group justify="space-between" align="flex-start" wrap="wrap">
           <Stack gap={4}>
             <Group gap="xs">
-              <CheckCircle2 size={22} color="#10b981" strokeWidth={2.5} />
+              <Archive size={22} color="var(--mantine-color-red-6)" strokeWidth={2.5} />
               <Text size="xl" fw={700} style={{ color: "var(--color-text-primary)" }}>
-                {processedImages.length} {processedImages.length === 1 ? "Image" : "Images"} Ready
+                Export Center
               </Text>
             </Group>
             <Text size="sm" c="dimmed">
-              All images have been optimized successfully
+              {processedImages.length} {processedImages.length === 1 ? "image" : "images"} ready to download
             </Text>
           </Stack>
           <Badge
             size="lg"
             variant="light"
             color="green"
-            leftSection={<Package size={16} />}
+            leftSection={<CheckCircle2 size={16} />}
           >
             {processedImages.length} {processedImages.length === 1 ? "file" : "files"}
           </Badge>
@@ -198,21 +202,23 @@ export function DownloadAll({ images, onClearAll }: DownloadAllProps) {
 
         {/* Action Buttons */}
         <Group justify="space-between" wrap="wrap" gap="md">
-          {onClearAll && (
+          {/* Left: Rename All button */}
+          {onBulkRename && (
             <Button
               size="md"
-              leftSection={<Trash2 size={18} />}
-              onClick={onClearAll}
+              leftSection={<Edit2 size={18} />}
+              onClick={() => setShowRenameModal(true)}
               variant="light"
-              color="gray"
+              color="blue"
             >
-              Clear All
+              Rename All
             </Button>
           )}
+          {/* Right: Download button */}
           <Button
             size="md"
             leftSection={<Download size={20} />}
-            rightSection={<Archive size={16} />}
+            rightSection={<Package size={16} />}
             onClick={handleDownloadAll}
             color="red"
             variant="filled"
@@ -222,6 +228,16 @@ export function DownloadAll({ images, onClearAll }: DownloadAllProps) {
           </Button>
         </Group>
       </Stack>
+
+      {/* Bulk Rename Modal */}
+      {onBulkRename && (
+        <BulkRenameModal
+          opened={showRenameModal}
+          onClose={() => setShowRenameModal(false)}
+          images={processedImages}
+          onApply={onBulkRename}
+        />
+      )}
     </Paper>
   );
 }

--- a/src/components/features/ImageCard.tsx
+++ b/src/components/features/ImageCard.tsx
@@ -292,9 +292,22 @@ export function ImageCard({ image, onRemove, onRegenerate, onCrop, globalSetting
                 : splitFileName(image.originalFile.name).base}
             </Text>
             {image.outputFormat && (
-              <Badge size="sm" variant="light" color="blue" style={{ textTransform: 'uppercase' }}>
-                {image.outputFormat === 'jpeg' ? 'JPG' : image.outputFormat}
-              </Badge>
+              <Tooltip
+                label={
+                  <>
+                    <Text size="xs" fw={600}>Export Format</Text>
+                    <Text size="xs" c="dimmed">
+                      Converted from: {splitFileName(image.originalFile.name).ext.replace('.', '').toUpperCase() || 'Unknown'}
+                    </Text>
+                  </>
+                }
+                withArrow
+                position="top"
+              >
+                <Badge size="sm" variant="light" color="blue" style={{ textTransform: 'uppercase', cursor: 'help' }}>
+                  {image.outputFormat === 'jpeg' ? 'JPG' : image.outputFormat}
+                </Badge>
+              </Tooltip>
             )}
             <Tooltip label="Edit filename">
               <ActionIcon

--- a/src/components/features/ImageCard.tsx
+++ b/src/components/features/ImageCard.tsx
@@ -285,12 +285,17 @@ export function ImageCard({ image, onRemove, onRegenerate, onCrop, globalSetting
             </ActionIcon>
           </Group>
         ) : (
-          <Group gap="xs" align="center">
+          <Group gap="xs" align="center" wrap="nowrap">
             <Text size="sm" fw={500} style={{ wordBreak: 'break-word', flex: 1 }}>
               {image.customFileName
-                ? `${image.customFileName}${splitFileName(image.originalFile.name).ext}`
-                : image.originalFile.name}
+                ? image.customFileName
+                : splitFileName(image.originalFile.name).base}
             </Text>
+            {image.outputFormat && (
+              <Badge size="sm" variant="light" color="blue" style={{ textTransform: 'uppercase' }}>
+                {image.outputFormat === 'jpeg' ? 'JPG' : image.outputFormat}
+              </Badge>
+            )}
             <Tooltip label="Edit filename">
               <ActionIcon
                 variant="subtle"

--- a/src/components/features/ImageProcessor.tsx
+++ b/src/components/features/ImageProcessor.tsx
@@ -272,7 +272,7 @@ export function ImageProcessor({
       )}
 
       {/* Batch download */}
-      <DownloadAll images={images} onClearAll={onClearAll} onBulkRename={onBulkRename} />
+      <DownloadAll images={images} onBulkRename={onBulkRename} />
     </div>
   );
 }

--- a/src/components/features/ImageProcessor.tsx
+++ b/src/components/features/ImageProcessor.tsx
@@ -110,6 +110,7 @@ interface ImageProcessorProps {
   onClearAll?: () => void;
   onReorderImages?: (images: ProcessedImage[]) => void;
   onUpdateFileName?: (imageId: string, fileName: string) => void;
+  onBulkRename?: (renamedFiles: Map<string, string>) => void;
   viewMode?: ViewMode;
 }
 
@@ -125,6 +126,7 @@ export function ImageProcessor({
   onClearAll,
   onReorderImages,
   onUpdateFileName,
+  onBulkRename,
   viewMode = "grid",
 }: ImageProcessorProps) {
   // Setup drag and drop sensors
@@ -270,7 +272,7 @@ export function ImageProcessor({
       )}
 
       {/* Batch download */}
-      <DownloadAll images={images} onClearAll={onClearAll} />
+      <DownloadAll images={images} onClearAll={onClearAll} onBulkRename={onBulkRename} />
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -386,3 +386,73 @@ input[type="range"]:focus::-moz-range-thumb {
   -webkit-backdrop-filter: blur(3px);
   z-index: -1;
 }
+
+/* Notification Toast Styling - High Specificity Override */
+/* Success notifications - Green background */
+.mantine-Notification-root[data-color="green"] {
+  background-color: #10b981 !important;
+  border: none !important;
+  color: white !important;
+}
+
+.mantine-Notification-root[data-color="green"] .mantine-Notification-title,
+.mantine-Notification-root[data-color="green"] .mantine-Notification-description,
+.mantine-Notification-root[data-color="green"] .mantine-Notification-body {
+  color: white !important;
+}
+
+/* Error notifications - Red background */
+.mantine-Notification-root[data-color="red"] {
+  background-color: #ef4444 !important;
+  border: none !important;
+  color: white !important;
+}
+
+.mantine-Notification-root[data-color="red"] .mantine-Notification-title,
+.mantine-Notification-root[data-color="red"] .mantine-Notification-description,
+.mantine-Notification-root[data-color="red"] .mantine-Notification-body {
+  color: white !important;
+}
+
+/* Warning notifications - Yellow/Amber background */
+.mantine-Notification-root[data-color="yellow"] {
+  background-color: #f59e0b !important;
+  border: none !important;
+  color: white !important;
+}
+
+.mantine-Notification-root[data-color="yellow"] .mantine-Notification-title,
+.mantine-Notification-root[data-color="yellow"] .mantine-Notification-description,
+.mantine-Notification-root[data-color="yellow"] .mantine-Notification-body {
+  color: white !important;
+}
+
+/* Info notifications - Blue background */
+.mantine-Notification-root[data-color="blue"] {
+  background-color: #3b82f6 !important;
+  border: none !important;
+  color: white !important;
+}
+
+.mantine-Notification-root[data-color="blue"] .mantine-Notification-title,
+.mantine-Notification-root[data-color="blue"] .mantine-Notification-description,
+.mantine-Notification-root[data-color="blue"] .mantine-Notification-body {
+  color: white !important;
+}
+
+/* Close button styling for colored notifications */
+.mantine-Notification-root[data-color="green"] .mantine-Notification-closeButton,
+.mantine-Notification-root[data-color="red"] .mantine-Notification-closeButton,
+.mantine-Notification-root[data-color="yellow"] .mantine-Notification-closeButton,
+.mantine-Notification-root[data-color="blue"] .mantine-Notification-closeButton {
+  color: white !important;
+  opacity: 0.8;
+}
+
+.mantine-Notification-root[data-color="green"] .mantine-Notification-closeButton:hover,
+.mantine-Notification-root[data-color="red"] .mantine-Notification-closeButton:hover,
+.mantine-Notification-root[data-color="yellow"] .mantine-Notification-closeButton:hover,
+.mantine-Notification-root[data-color="blue"] .mantine-Notification-closeButton:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.1) !important;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -44,7 +44,41 @@ const theme = createTheme({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <MantineProvider theme={theme} defaultColorScheme={loadDarkMode() ? 'dark' : 'light'}>
-      <Notifications position="top-right" />
+      <Notifications
+        position="bottom-right"
+        styles={{
+          notification: {
+            '&[data-color="green"]': {
+              backgroundColor: '#10b981',
+              color: 'white',
+              border: 'none',
+              '& .mantine-Notification-title': { color: 'white' },
+              '& .mantine-Notification-description': { color: 'white' },
+            },
+            '&[data-color="red"]': {
+              backgroundColor: '#ef4444',
+              color: 'white',
+              border: 'none',
+              '& .mantine-Notification-title': { color: 'white' },
+              '& .mantine-Notification-description': { color: 'white' },
+            },
+            '&[data-color="yellow"]': {
+              backgroundColor: '#f59e0b',
+              color: 'white',
+              border: 'none',
+              '& .mantine-Notification-title': { color: 'white' },
+              '& .mantine-Notification-description': { color: 'white' },
+            },
+            '&[data-color="blue"]': {
+              backgroundColor: '#3b82f6',
+              color: 'white',
+              border: 'none',
+              '& .mantine-Notification-title': { color: 'white' },
+              '& .mantine-Notification-description': { color: 'white' },
+            },
+          },
+        }}
+      />
       <App />
     </MantineProvider>
   </StrictMode>

--- a/src/utils/namingFormats.ts
+++ b/src/utils/namingFormats.ts
@@ -92,8 +92,8 @@ export const NAMING_FORMATS: NamingFormat[] = [
       const number = startNumber + index;
       const paddedNumber = padNumber(number, totalCount + startNumber - 1);
       const ext = getExtension(outputFormat);
-      // Sanitize prefix (remove invalid characters)
-      const sanitizedPrefix = prefix.replace(/[^a-zA-Z0-9_-]/g, '_');
+      // Sanitize prefix (remove invalid characters, preserve Unicode letters/numbers)
+      const sanitizedPrefix = prefix.replace(/[^\p{L}\p{N}_-]/gu, '_');
       return `${sanitizedPrefix}_${paddedNumber}${ext}`;
     },
   },

--- a/src/utils/namingFormats.ts
+++ b/src/utils/namingFormats.ts
@@ -1,0 +1,192 @@
+/**
+ * Naming format utilities for bulk file renaming
+ */
+
+export interface NamingFormatParams {
+  index: number; // 0-based index
+  totalCount: number;
+  originalName: string;
+  outputFormat: string; // 'jpeg', 'png', 'webp', 'avif'
+  prefix?: string;
+  startNumber?: number;
+}
+
+export interface NamingFormat {
+  id: 'sequential' | 'custom-prefix' | 'date-sequential' | 'preserve-suffix';
+  name: string;
+  description: string;
+  requiresPrefix: boolean;
+  generate: (params: NamingFormatParams) => string;
+}
+
+/**
+ * Get file extension based on output format
+ */
+function getExtension(format: string): string {
+  switch (format.toLowerCase()) {
+    case 'jpeg':
+      return '.jpg';
+    case 'png':
+      return '.png';
+    case 'webp':
+      return '.webp';
+    case 'avif':
+      return '.avif';
+    default:
+      return '.jpg';
+  }
+}
+
+/**
+ * Strip extension from filename
+ */
+function stripExtension(filename: string): string {
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot <= 0) return filename;
+  return filename.substring(0, lastDot);
+}
+
+/**
+ * Smart padding - uses 3 digits for <1000 images, 4 digits for >=1000
+ */
+function padNumber(num: number, totalCount: number): string {
+  const digits = totalCount >= 1000 ? 4 : 3;
+  return num.toString().padStart(digits, '0');
+}
+
+/**
+ * Get current date in YYYY-MM-DD format
+ */
+function getCurrentDate(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Available naming formats
+ */
+export const NAMING_FORMATS: NamingFormat[] = [
+  {
+    id: 'sequential',
+    name: 'Sequential',
+    description: 'Simple numbered sequence (image_001, image_002, ...)',
+    requiresPrefix: false,
+    generate: (params: NamingFormatParams): string => {
+      const { index, totalCount, outputFormat, startNumber = 1 } = params;
+      const number = startNumber + index;
+      const paddedNumber = padNumber(number, totalCount + startNumber - 1);
+      const ext = getExtension(outputFormat);
+      return `image_${paddedNumber}${ext}`;
+    },
+  },
+  {
+    id: 'custom-prefix',
+    name: 'Custom Prefix',
+    description: 'Your prefix + numbers (myprefix_001, myprefix_002, ...)',
+    requiresPrefix: true,
+    generate: (params: NamingFormatParams): string => {
+      const { index, totalCount, outputFormat, prefix = 'image', startNumber = 1 } = params;
+      const number = startNumber + index;
+      const paddedNumber = padNumber(number, totalCount + startNumber - 1);
+      const ext = getExtension(outputFormat);
+      // Sanitize prefix (remove invalid characters)
+      const sanitizedPrefix = prefix.replace(/[^a-zA-Z0-9_-]/g, '_');
+      return `${sanitizedPrefix}_${paddedNumber}${ext}`;
+    },
+  },
+  {
+    id: 'date-sequential',
+    name: 'Date + Sequential',
+    description: 'Date prefix + numbers (img-2025-10-01_001, ...)',
+    requiresPrefix: false,
+    generate: (params: NamingFormatParams): string => {
+      const { index, totalCount, outputFormat, startNumber = 1 } = params;
+      const number = startNumber + index;
+      const paddedNumber = padNumber(number, totalCount + startNumber - 1);
+      const ext = getExtension(outputFormat);
+      const date = getCurrentDate();
+      return `img-${date}_${paddedNumber}${ext}`;
+    },
+  },
+  {
+    id: 'preserve-suffix',
+    name: 'Preserve Original + Suffix',
+    description: 'Keep original name, add suffix (photo_optimized, vacation_optimized, ...)',
+    requiresPrefix: false,
+    generate: (params: NamingFormatParams): string => {
+      const { originalName, outputFormat } = params;
+      const baseName = stripExtension(originalName);
+      const ext = getExtension(outputFormat);
+      return `${baseName}_optimized${ext}`;
+    },
+  },
+];
+
+/**
+ * Get naming format by ID
+ */
+export function getNamingFormatById(id: string): NamingFormat | undefined {
+  return NAMING_FORMATS.find((format) => format.id === id);
+}
+
+/**
+ * Generate preview of filenames (first N examples)
+ */
+export function generatePreview(
+  formatId: string,
+  images: Array<{ originalName: string; outputFormat: string }>,
+  options: { prefix?: string; startNumber?: number; previewCount?: number } = {}
+): string[] {
+  const format = getNamingFormatById(formatId);
+  if (!format) return [];
+
+  const { prefix = '', startNumber = 1, previewCount = 3 } = options;
+  const totalCount = images.length;
+  const count = Math.min(previewCount, images.length);
+
+  return images.slice(0, count).map((image, index) =>
+    format.generate({
+      index,
+      totalCount,
+      originalName: image.originalName,
+      outputFormat: image.outputFormat,
+      prefix,
+      startNumber,
+    })
+  );
+}
+
+/**
+ * Bulk rename - generate all filenames for all images
+ */
+export function bulkRename(
+  formatId: string,
+  images: Array<{ id: string; originalName: string; outputFormat: string }>,
+  options: { prefix?: string; startNumber?: number } = {}
+): Map<string, string> {
+  const format = getNamingFormatById(formatId);
+  if (!format) return new Map();
+
+  const { prefix = '', startNumber = 1 } = options;
+  const totalCount = images.length;
+  const result = new Map<string, string>();
+
+  images.forEach((image, index) => {
+    const newName = format.generate({
+      index,
+      totalCount,
+      originalName: image.originalName,
+      outputFormat: image.outputFormat,
+      prefix,
+      startNumber,
+    });
+    // Store without extension (extension added during download)
+    const nameWithoutExt = stripExtension(newName);
+    result.set(image.id, nameWithoutExt);
+  });
+
+  return result;
+}

--- a/src/utils/namingFormats.ts
+++ b/src/utils/namingFormats.ts
@@ -114,13 +114,15 @@ export const NAMING_FORMATS: NamingFormat[] = [
   {
     id: 'preserve-suffix',
     name: 'Preserve Original + Suffix',
-    description: 'Keep original name, add suffix (photo_optimized, vacation_optimized, ...)',
+    description: 'Keep original name, add suffix (photo_optimized_001, vacation_optimized_002, ...)',
     requiresPrefix: false,
     generate: (params: NamingFormatParams): string => {
-      const { originalName, outputFormat } = params;
+      const { originalName, outputFormat, index, totalCount, startNumber = 1 } = params;
       const baseName = stripExtension(originalName);
       const ext = getExtension(outputFormat);
-      return `${baseName}_optimized${ext}`;
+      const number = startNumber + index;
+      const paddedNumber = padNumber(number, totalCount + startNumber - 1);
+      return `${baseName}_optimized_${paddedNumber}${ext}`;
     },
   },
 ];


### PR DESCRIPTION
Add comprehensive bulk rename feature allowing users to rename all processed images at once using predefined naming formats. This transforms ImgCrush into a more powerful image optimization and organization tool.

Features:
- 4 naming formats: Sequential, Custom Prefix, Date + Sequential, Preserve Original + Suffix
- Smart number padding (3-digit default, auto-adjusts for 1000+ images)
- Live preview showing first 3 renamed files
- Custom prefix input with sanitization
- Configurable start number
- Extension auto-matching based on output format
- New "Export Center" interface with improved button layout

Files changed:
- Created src/utils/namingFormats.ts - Format generators and utilities
- Created src/components/features/BulkRenameModal.tsx - Rename modal UI
- Modified src/App.tsx - Added handleBulkRename callback
- Modified src/components/features/ImageProcessor.tsx - Pass onBulkRename prop
- Modified src/components/features/DownloadAll.tsx - Integrated rename button and updated UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk rename processed images via a modal with multiple naming formats, optional prefix, start number, and live preview; renamed files apply across the app and show a success notice with count.
  * “Rename All” action added to the Export Center to trigger bulk renames.

* **UI**
  * Export Center labels, icons, and batch actions updated to expose the rename workflow.
  * Image items show custom filenames (no ext) and an export-format badge with tooltip.
  * Notifications moved to bottom-right with refreshed color styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->